### PR TITLE
Automatic udev restart

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,3 +4,4 @@
 
 install -m 755 -o root k290_fnkeyctl /usr/local/sbin/
 install -m 644 -o root 99-k290-config.rules /etc/udev/rules.d/
+service udev restart


### PR DESCRIPTION
See #3.

Automatic service restart, however will only work on debian-like OS.

Maybe we can simply update the README.
