### PR TITLE
bugfix to work on ubuntu

### DIFF
--- a/99-k290-config.rules
+++ b/99-k290-config.rules
@@ -1,1 +1,1 @@
-ATTR{idVendor}=="046d", ATTR{idProduct}=="c31f", RUN+="/usr/sbin/k290_fnkeyctl"
+ATTR{idVendor}=="046d", ATTR{idProduct}=="c31f", RUN+="/usr/local/sbin/k290_fnkeyctl"

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 # comment in or out to whatever compiler you prefer
 # if you want to use GCC, make sure it's a recent one
-g++ -std=gnu++0x -lusb-1.0 k290_fnkeyctl.cpp -o k290_fnkeyctl
+g++ -std=gnu++0x k290_fnkeyctl.cpp `pkg-config --libs libusb-1.0` -o k290_fnkeyctl
 # clang -std=c++11 -I/usr/include -L/usr/lib k290_fnkeyctl.cpp -lusb-1.0 -lstdc++ -o k290_fnkeyctl


### PR DESCRIPTION
Hello,
thank you for your great work!
I've done some changes to run the script under ubuntu.
In the config.rules file I changed the path of the script to be same of  the install script.
In the build.sh file I needed to change the line in this way otherwise Ubuntu doesn't recognize the usb libraries, I don't know if the problem exists on other distros.
Best regards,

Mike

P.s. This is the first pull request of my life :)
